### PR TITLE
added the operation mode and current setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also provides a python binding available via pip.
 ## To install locally 
 ```bash
 pip install maturin
-``
+```
 
 ## To build the wheel
 ```bash

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -57,6 +57,26 @@ impl ReachyMiniMotorController {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 
+    fn read_stewart_platform_current(&self) -> PyResult<[i16; 6]> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .read_stewart_platform_current()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
+    fn read_stewart_platform_operating_mode(&self) -> PyResult<[u8; 6]> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .read_stewart_platform_operating_mode()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+    }
+
     fn set_all_goal_positions(&self, positions: [f64; 9]) -> PyResult<()> {
         let mut inner = self.inner.lock().map_err(|_| {
             pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
@@ -111,6 +131,75 @@ impl ReachyMiniMotorController {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         Ok(())
     }
+
+    fn set_stewart_platform_operating_mode(&self, mode: u8) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .set_stewart_platform_operating_mode(mode)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    fn set_antennas_operating_mode(&self, mode: u8) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .set_antennas_operating_mode(mode)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+
+
+    fn set_body_rotation_operating_mode(&self, mode: u8) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .set_body_rotation_operating_mode(mode)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    fn enable_body_rotation(&self, enable: bool) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .enable_body_rotation(enable)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    fn enable_antennas(&self, enable: bool) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .enable_antennas(enable)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    fn enable_stewart_platform(&self, enable: bool) -> PyResult<()> {
+        let mut inner = self.inner.lock().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("Failed to lock motor controller")
+        })?;
+
+        inner
+            .enable_stewart_platform(enable)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
 }
 
 #[pyo3::pymodule]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -137,4 +137,106 @@ impl ReachyMiniMotorController {
 
         Ok(())
     }
+
+    pub fn read_stewart_platform_current(
+        &mut self,
+    ) -> Result<[i16; 6], Box<dyn std::error::Error>> {
+        let currents = xl330::sync_read_present_current(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6],
+        )?;
+
+        Ok(currents.try_into().unwrap())
+    }
+
+    pub fn set_stewart_platform_operating_mode(
+        &mut self,
+        mode: u8,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        xl330::sync_write_operating_mode(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6],
+            &[mode; 6],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn read_stewart_platform_operating_mode(
+        &mut self,
+    ) -> Result<[u8; 6], Box<dyn std::error::Error>> {
+        let modes = xl330::sync_read_operating_mode(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6],
+        )?;
+
+        Ok(modes.try_into().unwrap())
+    }
+
+    pub fn set_antennas_operating_mode(
+        &mut self,
+        mode: u8,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        sts3215::sync_write_mode(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &[21, 22],
+            &[mode; 2],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn set_body_rotation_operating_mode(
+        &mut self,
+        mode: u8,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        sts3215::sync_write_mode(
+            &self.dph_v1,
+            self.serial_port.as_mut(),
+            &[11],
+            &[mode],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn enable_body_rotation(&mut self, enable: bool) -> Result<(), Box<dyn std::error::Error>> {
+        sts3215::sync_write_torque_enable(
+            &self.dph_v1,
+            self.serial_port.as_mut(),
+            &[11],
+            &[enable],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn enable_antennas(&mut self, enable: bool) -> Result<(), Box<dyn std::error::Error>> {
+        sts3215::sync_write_torque_enable(
+            &self.dph_v1,
+            self.serial_port.as_mut(),
+            &[21, 22],
+            &[enable; 2],
+        )?;
+
+        Ok(())
+    }
+
+    pub fn enable_stewart_platform(&mut self, enable: bool) -> Result<(), Box<dyn std::error::Error>> {
+        xl330::sync_write_torque_enable(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &[1, 2, 3, 4, 5, 6],
+            &[enable; 6],
+        )?;
+
+        Ok(())
+    }
+
+
+
 }


### PR DESCRIPTION
Salut Pierre,

I've extended the API to account for the operating mode changing and current target setting. 
But for now, only the dynamixel motors allow setting the torque control. 

If I understood well, this will change, no more feetech right?
If that's true we will need to update the repo.