### PR TITLE
Avoid unwrap in lock for cleaner error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "reachy-mini-motor-controller"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "clap",
  "env_logger 0.11.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reachy-mini-motor-controller"
-version = "1.5.3"
+version = "1.5.4"
 edition = "2024"
 
 [lib]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.5.4
+
+* Avoid lock poisoning when run loop panic.
+
 ### v1.5.3
 
 * Improve error handling in the control loop to prevent panics.

--- a/src/control_loop.rs
+++ b/src/control_loop.rs
@@ -239,6 +239,13 @@ impl std::fmt::Display for MotorError {
                     port
                 )
             }
+            MotorError::CouldNotOpenPort(port) => {
+                write!(
+                    f,
+                    "Could not open serial port: {}! Check permissions and if the port is already in use.",
+                    port
+                )
+            }
             MotorError::VoltageRampUpTimeoutError(voltage, duration) => {
                 write!(
                     f,


### PR DESCRIPTION
If the background run loop panic, the lock can become poisoned and the unwrap will panic the main loop.
Better handle this case to raise better error.