### PR TITLE
Fix unbounded growth of ControlLoopStats vectors

### DIFF
--- a/src/control_loop.rs
+++ b/src/control_loop.rs
@@ -571,8 +571,11 @@ fn run(
     tokio::runtime::Runtime::new().unwrap().block_on(async {
         let mut interval = time::interval(read_position_loop_period);
 
-        // Stats related variables
+        // Stats related variables. Buffered locally and swapped into the shared
+        // stats at each publish so they describe only the last window (otherwise
+        // they would grow unbounded for the lifetime of the loop).
         let mut stats_t0 = std::time::Instant::now();
+        let mut period = Vec::new();
         let mut read_dt = Vec::new();
         let mut write_dt = Vec::new();
 
@@ -593,8 +596,8 @@ fn run(
                 }
                 _ = interval.tick() => {
                     let read_tick = std::time::Instant::now();
-                    if let Some((_, stats)) = &last_stats {
-                        stats.lock().unwrap().period.push(read_tick.duration_since(last_read_tick).as_secs_f64());
+                    if last_stats.is_some() {
+                        period.push(read_tick.duration_since(last_read_tick).as_secs_f64());
                         last_read_tick = read_tick;
                     }
 
@@ -624,13 +627,15 @@ fn run(
                         read_dt.push(elapsed);
                     }
 
-                    if let Some((period, stats)) = &last_stats
-                        && stats_t0.elapsed() > *period {
-                            stats.lock().unwrap().read_dt.extend(read_dt.iter().cloned());
-                            stats.lock().unwrap().write_dt.extend(write_dt.iter().cloned());
-
-                            read_dt.clear();
-                            write_dt.clear();
+                    if let Some((stats_pub_period, stats)) = &last_stats
+                        && stats_t0.elapsed() > *stats_pub_period {
+                            // Swap the buffered window into the shared stats,
+                            // leaving the local buffers empty for the next one.
+                            let mut s = stats.lock().unwrap();
+                            s.period = std::mem::take(&mut period);
+                            s.read_dt = std::mem::take(&mut read_dt);
+                            s.write_dt = std::mem::take(&mut write_dt);
+                            drop(s);
                             stats_t0 = std::time::Instant::now();
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #43.

The `period`, `read_dt` and `write_dt` vectors in the shared `ControlLoopStats` were appended to but **never cleared**, so they grew for the entire lifetime of the control loop. At 50 Hz that is ~50 entries/s/vector (~900k each over 5 h, ~20 MB+ total), and `get_stats()` re-clones the ever-growing vectors on every call. `reachy_mini`'s daemon runs the loop with `stats_pub_period=1s`, so it accumulated this for as long as it stayed up.

## Fix

Buffer the samples in local `Vec`s and swap them into the shared stats at each publish via `std::mem::take`, leaving the locals empty for the next window:

- `period` is now collected locally (was pushed straight to the shared struct).
- at publish, the shared `period`/`read_dt`/`write_dt` are **replaced** (not extended) with the last window's samples.

Memory is now bounded to one `stats_pub_period` window, and `get_stats()` stays cheap. `get_stats()` now reports the **last window** (~`stats_pub_period`, 1 s in production) instead of the whole history — note this is a small semantic change for any caller that assumed cumulative samples.

`cargo check` passes.

## Test plan

- [x] `cargo check`
- [ ] Run the soak test (pollen-robotics/reachy_mini#1198) and confirm RSS is now flat over 5 h+.

Assisted-by: Claude:claude-opus-4-8
