### PR TITLE
Add batch motor health reads

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -546,9 +546,10 @@ impl ReachyMiniPyControlLoop {
     }
 
     /// Read the hardware error status of all servos with one sync-read.
-    fn async_read_all_hardware_error_statuses(&self) -> PyResult<HashMap<u8, u8>> {
-        self.inner
-            .async_read_all_hardware_error_statuses()
+    /// Raises an error instead of returning partial data if any servo does not respond.
+    fn async_read_all_hardware_error_statuses(&self, py: Python<'_>) -> PyResult<HashMap<u8, u8>> {
+        let inner = self.inner.clone();
+        py.detach(move || inner.async_read_all_hardware_error_statuses())
             .map_err(|e| {
                 pyo3::exceptions::PyRuntimeError::new_err(format!(
                     "Failed to read hardware error statuses: {}",
@@ -558,13 +559,16 @@ impl ReachyMiniPyControlLoop {
     }
 
     /// Read the current input voltage of all servos with one sync-read.
-    fn async_read_all_voltages(&self) -> PyResult<HashMap<u8, u16>> {
-        self.inner.async_read_all_voltages().map_err(|e| {
-            pyo3::exceptions::PyRuntimeError::new_err(format!(
-                "Failed to read input voltages: {}",
-                e
-            ))
-        })
+    /// Raises an error instead of returning partial data if any servo does not respond.
+    fn async_read_all_voltages(&self, py: Python<'_>) -> PyResult<HashMap<u8, u16>> {
+        let inner = self.inner.clone();
+        py.detach(move || inner.async_read_all_voltages())
+            .map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "Failed to read input voltages: {}",
+                    e
+                ))
+            })
     }
 
     /// Perform an asynchronous raw write of motor bytes.

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -545,6 +545,28 @@ impl ReachyMiniPyControlLoop {
             })
     }
 
+    /// Read the hardware error status of all servos with one sync-read.
+    fn async_read_all_hardware_error_statuses(&self) -> PyResult<HashMap<u8, u8>> {
+        self.inner
+            .async_read_all_hardware_error_statuses()
+            .map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "Failed to read hardware error statuses: {}",
+                    e
+                ))
+            })
+    }
+
+    /// Read the current input voltage of all servos with one sync-read.
+    fn async_read_all_voltages(&self) -> PyResult<HashMap<u8, u16>> {
+        self.inner.async_read_all_voltages().map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "Failed to read input voltages: {}",
+                e
+            ))
+        })
+    }
+
     /// Perform an asynchronous raw write of motor bytes.
     /// # Arguments
     /// * `id` - Motor ID to write to.

--- a/src/control_loop.rs
+++ b/src/control_loop.rs
@@ -516,6 +516,7 @@ impl ReachyMiniControlLoop {
     }
 
     /// Read the hardware error status of all servos with one sync-read.
+    /// Returns an error instead of partial data if any servo does not respond.
     pub fn async_read_all_hardware_error_statuses(&self) -> Result<HashMap<u8, u8>, MotorError> {
         let (tx, rx) = std::sync::mpsc::channel();
         self.push_command(MotorCommand::ReadAllHardwareErrorStatuses { tx })
@@ -525,6 +526,7 @@ impl ReachyMiniControlLoop {
     }
 
     /// Read the current input voltage of all servos with one sync-read.
+    /// Returns an error instead of partial data if any servo does not respond.
     pub fn async_read_all_voltages(&self) -> Result<HashMap<u8, u16>, MotorError> {
         let (tx, rx) = std::sync::mpsc::channel();
         self.push_command(MotorCommand::ReadAllVoltages { tx })

--- a/src/control_loop.rs
+++ b/src/control_loop.rs
@@ -161,6 +161,12 @@ pub enum MotorCommand {
         length: u8,
         tx: std::sync::mpsc::Sender<Vec<u8>>,
     },
+    ReadAllHardwareErrorStatuses {
+        tx: std::sync::mpsc::Sender<HashMap<u8, u8>>,
+    },
+    ReadAllVoltages {
+        tx: std::sync::mpsc::Sender<HashMap<u8, u16>>,
+    },
     WriteRawBytes {
         id: u8,
         addr: u8,
@@ -509,6 +515,24 @@ impl ReachyMiniControlLoop {
             .map_err(|_| MotorError::CommunicationError())
     }
 
+    /// Read the hardware error status of all servos with one sync-read.
+    pub fn async_read_all_hardware_error_statuses(&self) -> Result<HashMap<u8, u8>, MotorError> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.push_command(MotorCommand::ReadAllHardwareErrorStatuses { tx })
+            .map_err(|_| MotorError::CommunicationError())?;
+        rx.recv_timeout(Duration::from_secs(1))
+            .map_err(|_| MotorError::CommunicationError())
+    }
+
+    /// Read the current input voltage of all servos with one sync-read.
+    pub fn async_read_all_voltages(&self) -> Result<HashMap<u8, u16>, MotorError> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.push_command(MotorCommand::ReadAllVoltages { tx })
+            .map_err(|_| MotorError::CommunicationError())?;
+        rx.recv_timeout(Duration::from_secs(1))
+            .map_err(|_| MotorError::CommunicationError())
+    }
+
     pub fn async_write_raw_bytes(&self, id: u8, addr: u8, data: Vec<u8>) -> Result<(), MotorError> {
         let command = MotorCommand::WriteRawBytes { id, addr, data };
         self.push_command(command)
@@ -752,6 +776,22 @@ fn handle_commands(
                 read_allowed_retries,
             )?;
             let _ = tx.send(data);
+            Ok(())
+        }
+        ReadAllHardwareErrorStatuses { tx } => {
+            let statuses = with_retry(
+                || controller.read_all_hardware_error_statuses(),
+                read_allowed_retries,
+            )?;
+            let _ = tx.send(statuses);
+            Ok(())
+        }
+        ReadAllVoltages { tx } => {
+            let voltages = with_retry(
+                || controller.read_all_voltages_by_id(),
+                read_allowed_retries,
+            )?;
+            let _ = tx.send(voltages);
             Ok(())
         }
         WriteRawBytes { id, addr, data } => {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,21 +13,8 @@ const ANTENNAS_IDS: [u8; 2] = [17, 18]; // Right and Left antennas
 const STEWART_PLATFORM_IDS: [u8; 6] = [11, 12, 13, 14, 15, 16];
 const BODY_ROTATION_ID: u8 = 10;
 
-fn values_by_id<T>(
-    ids: &[u8],
-    values: impl IntoIterator<Item = T>,
-) -> Result<HashMap<u8, T>, Box<dyn std::error::Error>> {
-    let values = values.into_iter().collect::<Vec<_>>();
-    if values.len() != ids.len() {
-        return Err(format!(
-            "Invalid response length: expected {} elements, got {}",
-            ids.len(),
-            values.len()
-        )
-        .into());
-    }
-
-    Ok(ids.iter().copied().zip(values).collect())
+fn values_by_id<T, const N: usize>(ids: &[u8; N], values: [T; N]) -> HashMap<u8, T> {
+    ids.iter().copied().zip(values).collect()
 }
 
 impl ReachyMiniMotorController {
@@ -76,17 +63,13 @@ impl ReachyMiniMotorController {
         on_error_status_only: bool,
         reboot_timeout: Duration,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut error_status = Vec::new();
+        let error_status = if on_error_status_only {
+            Some(self.read_all_hardware_error_statuses_ordered()?)
+        } else {
+            None
+        };
 
-        if on_error_status_only {
-            error_status = xl330::sync_read_hardware_error_status(
-                &self.dph_v2,
-                self.serial_port.as_mut(),
-                &self.all_ids,
-            )?;
-        }
-
-        let faulty_ids: Vec<u8> = if on_error_status_only {
+        let faulty_ids: Vec<u8> = if let Some(error_status) = error_status {
             self.all_ids
                 .iter()
                 .zip(error_status.iter())
@@ -179,25 +162,40 @@ impl ReachyMiniMotorController {
 
     /// Read the current input voltage of all servos with one sync-read.
     /// Returns a map keyed by servo ID.
+    ///
+    /// The read is atomic from the caller's perspective: if any servo does not
+    /// respond, the method returns an error rather than a partial map.
     pub fn read_all_voltages_by_id(
         &mut self,
     ) -> Result<HashMap<u8, u16>, Box<dyn std::error::Error>> {
         let voltages = self.read_all_voltages()?;
-        values_by_id(&self.all_ids, voltages)
+        Ok(values_by_id(&self.all_ids, voltages))
     }
 
     /// Read the hardware error status of all servos with one sync-read.
     /// Returns a map keyed by servo ID.
+    ///
+    /// The read is atomic from the caller's perspective: if any servo does not
+    /// respond, the method returns an error rather than a partial map.
     pub fn read_all_hardware_error_statuses(
         &mut self,
     ) -> Result<HashMap<u8, u8>, Box<dyn std::error::Error>> {
+        let statuses = self.read_all_hardware_error_statuses_ordered()?;
+        Ok(values_by_id(&self.all_ids, statuses))
+    }
+
+    fn read_all_hardware_error_statuses_ordered(
+        &mut self,
+    ) -> Result<[u8; 9], Box<dyn std::error::Error>> {
         let statuses = xl330::sync_read_hardware_error_status(
             &self.dph_v2,
             self.serial_port.as_mut(),
             &self.all_ids,
         )?;
 
-        values_by_id(&self.all_ids, statuses)
+        statuses
+            .try_into()
+            .map_err(|_| "Invalid hardware error status array length: expected 9 elements".into())
     }
 
     /// Read the current position of all servos.
@@ -475,20 +473,10 @@ mod tests {
 
     #[test]
     fn values_by_id_preserves_servo_association() {
-        let values = values_by_id(&[10, 11, 17], [100, 110, 170]).unwrap();
+        let values = values_by_id(&[10, 11, 17], [100, 110, 170]);
 
         assert_eq!(values.get(&10), Some(&100));
         assert_eq!(values.get(&11), Some(&110));
         assert_eq!(values.get(&17), Some(&170));
-    }
-
-    #[test]
-    fn values_by_id_rejects_incomplete_responses() {
-        let error = values_by_id(&[10, 11, 17], [100, 110]).unwrap_err();
-
-        assert_eq!(
-            error.to_string(),
-            "Invalid response length: expected 3 elements, got 2"
-        );
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -13,6 +13,23 @@ const ANTENNAS_IDS: [u8; 2] = [17, 18]; // Right and Left antennas
 const STEWART_PLATFORM_IDS: [u8; 6] = [11, 12, 13, 14, 15, 16];
 const BODY_ROTATION_ID: u8 = 10;
 
+fn values_by_id<T>(
+    ids: &[u8],
+    values: impl IntoIterator<Item = T>,
+) -> Result<HashMap<u8, T>, Box<dyn std::error::Error>> {
+    let values = values.into_iter().collect::<Vec<_>>();
+    if values.len() != ids.len() {
+        return Err(format!(
+            "Invalid response length: expected {} elements, got {}",
+            ids.len(),
+            values.len()
+        )
+        .into());
+    }
+
+    Ok(ids.iter().copied().zip(values).collect())
+}
+
 impl ReachyMiniMotorController {
     pub fn new(serialport: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let dph_v2 = rustypot::DynamixelProtocolHandler::v2();
@@ -159,7 +176,29 @@ impl ReachyMiniMotorController {
         volt.try_into()
             .map_err(|_| "Invalid voltage array length: expected 9 elements".into())
     }
-        
+
+    /// Read the current input voltage of all servos with one sync-read.
+    /// Returns a map keyed by servo ID.
+    pub fn read_all_voltages_by_id(
+        &mut self,
+    ) -> Result<HashMap<u8, u16>, Box<dyn std::error::Error>> {
+        let voltages = self.read_all_voltages()?;
+        values_by_id(&self.all_ids, voltages)
+    }
+
+    /// Read the hardware error status of all servos with one sync-read.
+    /// Returns a map keyed by servo ID.
+    pub fn read_all_hardware_error_statuses(
+        &mut self,
+    ) -> Result<HashMap<u8, u8>, Box<dyn std::error::Error>> {
+        let statuses = xl330::sync_read_hardware_error_status(
+            &self.dph_v2,
+            self.serial_port.as_mut(),
+            &self.all_ids,
+        )?;
+
+        values_by_id(&self.all_ids, statuses)
+    }
 
     /// Read the current position of all servos.
     /// Returns an array of 9 positions in the following order:
@@ -427,5 +466,29 @@ impl ReachyMiniMotorController {
         self.serial_port.read_exact(&mut buff)?;
 
         Ok(buff)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::values_by_id;
+
+    #[test]
+    fn values_by_id_preserves_servo_association() {
+        let values = values_by_id(&[10, 11, 17], [100, 110, 170]).unwrap();
+
+        assert_eq!(values.get(&10), Some(&100));
+        assert_eq!(values.get(&11), Some(&110));
+        assert_eq!(values.get(&17), Some(&170));
+    }
+
+    #[test]
+    fn values_by_id_rejects_incomplete_responses() {
+        let error = values_by_id(&[10, 11, 17], [100, 110]).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Invalid response length: expected 3 elements, got 2"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add batch hardware-error and input-voltage reads keyed by servo ID
- expose the reads through the control loop and Python bindings
- reuse the ordered hardware-status read in `reboot()`
- release the Python GIL while waiting for batch-read responses

The new methods use one Dynamixel sync-read request instead of issuing a separate command for every servo. This reduces command dispatch and serial request overhead for periodic motor health monitoring.

## Read semantics

Batch reads are all-or-nothing. If any servo does not respond, the method returns an error rather than a partial map. This behavior is documented in the Rust API and generated Python stubs.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets`
- `cargo run --bin stub_gen`
- `git diff --check`

Clippy reports only the warnings already present on `main`.
